### PR TITLE
Ensure "endstream" marker is always preceded by a newline

### DIFF
--- a/lib/Text/PDF/Dict.pm
+++ b/lib/Text/PDF/Dict.pm
@@ -175,7 +175,7 @@ sub outobjdeep
                 $pdf->out_obj($self->{'Length'}) if ($self->{'Length'}->is_obj($pdf));
             }
         }
-        $fh->print("\n") unless ($str =~ m/$cr$/o);
+        $fh->print("\n");
         $fh->print("endstream");
 #        $self->{'Length'}->outobjdeep($fh);
     } elsif (defined $self->{' streamfile'})


### PR DESCRIPTION
When a stream consists of binary data (e.g. has the FlateDecode filter applied), the final byte might possibly be a Line Feed or a Carriage Return character which will trigger the conditional to skip adding the newline before the EndStream marker.  This in turn will mean that the number of bytes between the "stream" and "endstream" does not match the "Length".
