### PR TITLE
Fix ToUnicode CMap generation in TTFont0

### DIFF
--- a/lib/Text/PDF/TTFont0.pm
+++ b/lib/Text/PDF/TTFont0.pm
@@ -125,10 +125,23 @@ sub new
                 $unistr .= "endbfchar\n";
                 $unistr .= "$s beginbfchar\n";
             }
-            $unistr .= sprintf("<%04x> <%04x>\n", $i, $rev[$i]);
+            my $uni = $rev[$i];
+            # ToUnicode destinations are UTF-16BE, so anything outside the
+            # BMP has to be written as a surrogate pair. find_ms() prefers
+            # the (3,10) UCS-4 subtable, so astral code points do reach here.
+            if ($uni > 0xFFFF)
+            {
+                my $v = $uni - 0x10000;
+                $unistr .= sprintf("<%04X> <%04X%04X>\n", $i,
+                                   0xD800 + ($v >> 10), 0xDC00 + ($v & 0x3FF));
+            }
+            else
+            {
+                $unistr .= sprintf("<%04X> <%04X>\n", $i, $uni);
+            }
             $j++;
         }
-        $unistr .= "endbfchar\nendcmap CMapName currendict /CMap defineresource pop end end\n";
+        $unistr .= "endbfchar\nendcmap CMapName currentdict /CMap defineresource pop end end\n";
         $touni = PDFDict();
         $parent->new_obj($touni);
         $touni->{' stream'} = $unistr;

--- a/lib/Text/PDF/TTFont0.pm
+++ b/lib/Text/PDF/TTFont0.pm
@@ -106,25 +106,29 @@ sub new
     if ($opt{'ToUnicode'})
     {
         @rev = $font->{'cmap'}->read->reverse;
-        $unistr = '/CIDInit /ProcSet findresource being 12 dict begin begincmap
+        my $num = grep defined, @rev;
+        $unistr = '/CIDInit /ProcSet findresource begin 12 dict begin begincmap
 /CIDSystemInfo << /Registry (' . $self->{'BaseFont'}->val . '+0) /Ordering (XYZ)
 /Supplement 0 >> def
 /CMapName /' . $self->{'BaseFont'}->val . '+0 def /CMapType 2 def
-1 begincodespacerange ';
-        $unistr .= sprintf("<%04X> <%04X> endcodespacerange\n", 1, $num - 1);
-        $unistr .= $num - $i > 100 ? 100 : $num - $i;
-        $unistr .= " beginbfrange";
-        for ($i = 1; $i < $num; $i++)
+1 begincodespacerange <0000> <FFFF> endcodespacerange'."\n";
+        for (my $i = my $j = 0; $i < @rev; $i++)
         {
-            if ($i % 100 == 0)
+            next unless defined $rev[$i];
+            my $s = $num - $j > 100 ? 100 : $num - $j;
+            if ($j == 0)
             {
-                $unistr .= "endbfrange\n";
-                $unistr .= $num - $i > 100 ? 100 : $num - $i;
-                $unistr .= " beginbfrange\n";
+                $unistr .= "$s beginbfchar\n";
             }
-            $unistr .= sprintf("<%04X> <%04X> <%04X>\n", $i, $i, $rev[$i]);
+            elsif ($j % 100 == 0)
+            {
+                $unistr .= "endbfchar\n";
+                $unistr .= "$s beginbfchar\n";
+            }
+            $unistr .= sprintf("<%04x> <%04x>\n", $i, $rev[$i]);
+            $j++;
         }
-        $unistr .= "endbfrange\nendcmap CMapName currendict /CMap defineresource pop end end\n";
+        $unistr .= "endbfchar\nendcmap CMapName currendict /CMap defineresource pop end end\n";
         $touni = PDFDict();
         $parent->new_obj($touni);
         $touni->{' stream'} = $unistr;


### PR DESCRIPTION
## Summary

- Fixes broken ToUnicode CMap generation in `Text::PDF::TTFont0` that caused text extraction/search to fail for PDFs using TrueType Type0 fonts
- Corrects typo ("being" → "begin"), uses `bfchar` instead of `bfrange`, makes codespacerange all-inclusive, skips undefined glyph mappings, and fixes loop variable scoping
- Based on patch by vadimr from [RT #123562](https://rt.cpan.org/Public/Bug/Display.html?id=123562)

## Details

The original ToUnicode CMap code had several issues:

1. **Typo in ProcSet call**: `findresource being` should be `findresource begin`
2. **Wrong CMap operator**: Used `bfrange` with identical start/end values (`<XXXX> <XXXX> <YYYY>`) instead of the simpler and correct `bfchar` (`<XXXX> <YYYY>`)
3. **Incorrect codespacerange**: Used glyph count as upper bound instead of all-inclusive `<0000> <FFFF>`
4. **No filtering of undefined mappings**: Iterated all glyphs including those without Unicode mappings, causing warnings and invalid CMap entries
5. **Incorrect section size counting**: Used `$num - $i` (total glyphs minus position) instead of counting only defined glyphs

These issues made text in PDFs generated with the `ToUnicode` option unsearchable and uncopyable in PDF viewers.

## Test plan

- [x] Verify the generated CMap structure is valid per the PDF specification (Section 9.10)
- [ ] Test with a TrueType font to confirm text is searchable/copyable in PDF viewers
- [ ] Verify no warnings from undefined glyph mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)